### PR TITLE
Update hxset.lua - Enquiry about modified packing offer on HxSet.

### DIFF
--- a/zh-CN/support/utils/hxset.lua
+++ b/zh-CN/support/utils/hxset.lua
@@ -3,7 +3,7 @@ HXSet = {
 }
 
 if PLATFORM_CODE == PLATFORM_CH then
-	slot0.codeMode = false
+	slot0.codeMode = true
 	slot0.antiSkinMode = true
 else
 	slot0.codeMode = true


### PR DESCRIPTION
Hello,

I'm an unexperienced software engineer and also a player in the Azurlane CN server.
As you know, due to many reasons, the game contents in CN server gets heavily censored, including the names of IJN ships. I didn't find a trivial way to change these, which are determined in lua scripts. Though limited in engineering technique, I still want a full game experience with CN environment.
That's why I ask if you are willing to offer a favor by packing new encrypted scripts(32, 64) for CN according to my modification in this commit (1 single line) and sending them in private. I know the reverse engineering methods can be dangerous and related to many security and legality issues, and in this way both enc/dec will not be leaked.

On the other hand, I would understand if you were still unable to offer any help. In this situation, I'd always be happy to learn more on reverse engineering. Now I've already tracked down those dlls in il2cpp, but unable to parse them without the main il2cpp executable. I wonder if those necessary information exists somewhere, and whether enc/dec are in those dlls? I'm quite curious about this. If this is inappropriate to discuss on github, may I reach you in private?

Thanks a lot for your time.